### PR TITLE
修复在客户端断开连接时，仍发送数据的错误

### DIFF
--- a/Assets/MagiCloud/Scripts/NetWorks/Scripts/Core/Control/ConnectControl.cs
+++ b/Assets/MagiCloud/Scripts/NetWorks/Scripts/Core/Control/ConnectControl.cs
@@ -75,6 +75,11 @@ namespace MagiCloud.NetWorks
 
         public void Send(ProtobufTool protobuf)
         {
+            if (!socket.Connected)
+            {
+                isUse=false;
+                return;
+            }
             try
             {
                 socket.BeginSend(protobuf.bytes,0,protobuf.byteLength,SocketFlags.None,SendCallback
@@ -89,7 +94,7 @@ namespace MagiCloud.NetWorks
 
         private void SendCallback(IAsyncResult ar)
         {
-           
+
             try
             {
                 ProtobufTool connect = ar.AsyncState as ProtobufTool;


### PR DESCRIPTION
请检查以下内容：
* 确保您的目标是主分支，发布分支上的拉取请求仅允许修复错误。
* 阅读行为准则，代码命名和文件是否规范处理: **命名规范.md**
* 描述您的拉取请求的作用以及您要定位的问题（如果有）

**您必须在发布前删除上述内容，包括此行，否则您的请求将无效。**
