### PR TITLE
修复在实验主动关闭时，进程缓冲未清空的问题

### DIFF
--- a/Assets/MagiCloud/Scripts/NetWorks/Scripts/Helper/ProcessHelper.cs
+++ b/Assets/MagiCloud/Scripts/NetWorks/Scripts/Helper/ProcessHelper.cs
@@ -54,8 +54,8 @@ namespace MagiCloud.NetWorks
             if (p!=null&&!p.HasExited)
             {
                 p.Kill();
-                p=null;
             }
+            p=null;
         }
     }
 }


### PR DESCRIPTION
请检查以下内容：
* 确保您的目标是主分支，发布分支上的拉取请求仅允许修复错误。
* 阅读行为准则，代码命名和文件是否规范处理: **命名规范.md**
* 描述您的拉取请求的作用以及您要定位的问题（如果有）

**您必须在发布前删除上述内容，包括此行，否则您的请求将无效。**
